### PR TITLE
Update minimum CMake version

### DIFF
--- a/utils_storage/README.rst
+++ b/utils_storage/README.rst
@@ -30,7 +30,7 @@ Requirements
 To use this plug-in you will need:
 
 - RTI Connext Professional version 6.0.0 or higher.
-- CMake version 3.5 or higher
+- CMake version 3.7 or higher
 - A target platform supported by *RTI* |RecS|.
 
 Capabilities and Usage


### PR DESCRIPTION
CMake version must be at least 3.7 to support the Find Package CMake scripts.